### PR TITLE
Add GitHub Actions workflow to build Windows executable

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,36 @@
+name: Build executable
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build executable with PyInstaller
+        run: pyinstaller server_runner.spec
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TransmissionWebServer-executable
+          path: dist/TransmissionWebServer


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the TransmissionWebServer executable with PyInstaller on Windows
- upload the generated executable as an artifact and allow manual, push, and release triggers

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0d560f284832880ad9643fe4de13b